### PR TITLE
Typo in VTabs tabList

### DIFF
--- a/src/components/VTabs/VTabs.vue
+++ b/src/components/VTabs/VTabs.vue
@@ -165,7 +165,7 @@ export default {
         this.$nextTick(() =>
           this.$emit('tabChange', {
             event,
-            tab: this.tablist[this.activeIndex],
+            tab: this.tabList[this.activeIndex],
             index: this.activeIndex,
           })
         );


### PR DESCRIPTION
switching tabs with keyboard throws. `this.tablist` should be `this.tabList`